### PR TITLE
Fix blank HTML load when served without Vite

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,29 @@
   </head>
   <body class="bg-slate-50 dark:bg-slate-900 text-slate-800 dark:text-slate-200 transition-colors duration-300">
     <div id="app"></div>
-    <script type="module" src="/src/main.ts"></script>
+    <script type="module">
+      const loadApp = async () => {
+        const currentUrl = import.meta.url;
+        const isDistBuild = currentUrl.includes('/dist/');
+        const assetBase = isDistBuild ? './assets/' : './dist/assets/';
+        const builtJsUrl = new URL(`${assetBase}index.js`, currentUrl).href;
+
+        if (currentUrl.endsWith('/dist/assets/index.js')) {
+          await import(new URL('./main.js', currentUrl).href);
+          return;
+        }
+
+        try {
+          await import(builtJsUrl);
+          return;
+        } catch (error) {
+          console.warn('無法載入預建版資源,改用開發模式載入。', error);
+        }
+
+        await import('/src/main.ts');
+      };
+
+      loadApp();
+    </script>
   </body>
 </html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,18 @@
 import { defineConfig } from 'vite';
+import { resolve } from 'node:path';
 
 export default defineConfig({
   base: './',
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+      },
+      output: {
+        entryFileNames: 'assets/index.js',
+        chunkFileNames: 'assets/[name].js',
+        assetFileNames: 'assets/[name][extname]',
+      },
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- add a dynamic bootstrap loader to `index.html` so the prebuilt bundle runs when the site is served statically and fallback to the Vite entry during development
- configure Vite to emit deterministic asset names, allowing the static loader to find the generated bundle

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1d3aad0b083228999a8f2c037dd9e